### PR TITLE
fix(docs): Make the modifier function examples clearer.

### DIFF
--- a/docs/docs/codes/modifiers.mdx
+++ b/docs/docs/codes/modifiers.mdx
@@ -41,6 +41,6 @@ These functions take the form: `XX(code)`
 - Some basic codes already include a modifier function in their definition:
   - `DOLLAR` = `LS(NUMBER_4)`
 - There are left- and right-handed versions of each modifier (also see table above):
-  - `LS`, `LC`, `LA`, `LG`, `RS`, `RC`, `RA`, `RG`
+  - `LS(x)`, `LC(x)`, `LA(x)`, `LG(x)`, `RS(x)`, `RC(x)`, `RA(x)`, `RG(x)`
 - Modified keys can safely be rolled-over. Modifier functions are released when another key is pressed.
   - Press `&kp LS(A)`, then press `&kp B`, release `&kp LS(A)` and release `&kp B` results in **Ab**. Only the A is capitalized.


### PR DESCRIPTION
* Ensure the list of available modifier functions is clearly shown as macros, not as basic defines.

<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->
## Board/Shield Check-list
 - [ ] This board/shield is tested working on real hardware
 - [ ] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
 - [ ] `.zmk.yml` metadata file added
 - [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
 - [ ] General consistent formatting of DeviceTree files
 - [ ] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
 - [ ] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
 - [ ] If split, no name added for the right/peripheral half
 - [ ] Kconfig.defconfig file correctly wraps *all* configuration in conditional on the shield symbol
 - [ ] `.conf` file has optional extra features commented out
 - [ ] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
